### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_nightly.yml
+++ b/.github/workflows/publish_nightly.yml
@@ -15,7 +15,7 @@ jobs:
       id: date
       run: echo "BUILD_DATE=$(date +'%Y-%m-%d %H:%M:%S %z')" >> $GITHUB_OUTPUT
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         VCS_REF: ${{ github.sha }}
         VERSION: nightly

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -18,7 +18,7 @@ jobs:
       id: version
       run: echo "::set-output name=version::$(echo ${{ github.ref }} | sed 's/refs\/tags\///' | sed 's/v//')"
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         VCS_REF: ${{ github.sha }}
         VERSION: ${{ github.ref }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore